### PR TITLE
perf: halved the time for computing collision area

### DIFF
--- a/src/util/collision.js
+++ b/src/util/collision.js
@@ -4,8 +4,7 @@ import intersect from '../intersect';
 // computes the area of overlap between the rectangle with the given index with the
 // rectangles in the array
 export const collisionArea = (rectangles, index) =>  d3.sum(
-        rectangles.filter((_, i) => index !== i)
-            .map((d) => intersect(rectangles[index], d))
+        rectangles.map((d, i) => (index === i) ? 0 : intersect(rectangles[index], d))
     );
 
 // computes the total overlapping area of all of the rectangles in the given array


### PR DESCRIPTION
From profiling, 83% of execution time is within the collisionArea function, by removing the filter step, simulated annealing of 20 labels (temp = 1000, cooling = 1) was reduced from 154ms to 67ms.

I also looked at the intersect logic, caching this 'x + width' style logic, but this didn't make any difference.